### PR TITLE
Update mysql to use real utf8 (utf8mb4)

### DIFF
--- a/mysql
+++ b/mysql
@@ -8,7 +8,7 @@ mysqldump --all-databases --all-routines -u root -p > ~/fulldump.sql
 mysql -u root -p  < ~/fulldump.sql
 
 # To create a database in utf8 charset
-CREATE DATABASE owa CHARACTER SET utf8 COLLATE utf8_general_ci;
+CREATE DATABASE owa CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 # Types of user permissions:
 


### PR DESCRIPTION
The utf8 in mySQL doesn't acutally create a real UTF8 database. It creates a proprietary subset. Real UTF8 in MySQL is called utf8mb4. Here's an article on the topic: [In MySQL, never use “utf8”. Use “utf8mb4”.](https://medium.com/@adamhooper/in-mysql-never-use-utf8-use-utf8mb4-11761243e434).